### PR TITLE
Sort fields in PojoFieldFactory for deterministic order

### DIFF
--- a/src/main/java/com/openpojo/reflection/impl/PojoFieldFactory.java
+++ b/src/main/java/com/openpojo/reflection/impl/PojoFieldFactory.java
@@ -19,7 +19,9 @@
 package com.openpojo.reflection.impl;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -40,7 +42,14 @@ public final class PojoFieldFactory {
    */
   public static List<PojoField> getPojoFields(final Class<?> clazz) {
     final List<PojoField> pojoFields = new LinkedList<PojoField>();
-    for (final Field field : clazz.getDeclaredFields()) {
+    Field[] declaredFields = clazz.getDeclaredFields();
+    Arrays.sort(declaredFields, new Comparator<Object>() {
+        @Override
+        public int compare(Object a, Object b) {
+          return a.toString().compareTo(b.toString());
+        }
+    });
+    for (final Field field : declaredFields) {
       pojoFields.add(new PojoFieldImpl(field));
     }
     return Collections.unmodifiableList(pojoFields);

--- a/src/test/java/com/openpojo/business/BusinessIdentityTest.java
+++ b/src/test/java/com/openpojo/business/BusinessIdentityTest.java
@@ -142,7 +142,7 @@ public class BusinessIdentityTest {
     final String toString = BusinessIdentity.toString(toStringTestData);
     Assert.assertTrue(String.format("BusinessIdentity.toString() failed!! recieved[%s]", toString),
         toString.startsWith("com.openpojo.business.BusinessIdentityTest$ToStringTestData [@")
-            && toString.endsWith(": instance_name=Instance Name, static_name=Static Name, STATIC_FINAL_NAME=Static Final Name]"));
+            && toString.endsWith(": instance_name=Instance Name, STATIC_FINAL_NAME=Static Final Name, static_name=Static Name]"));
   }
 
   @Test


### PR DESCRIPTION
The test `BusinessIdentityTest.testToString` compares the result with a hardcoded string. However, the function `BusinessIdentity.toString` did not return the deterministic string. From code trace, the root cause is the method `PojoFieldFactory.getPojoFields`, which calls on Java's reflection api `getDeclaredFields`. There is no guarantee in order of the returned fields and thus, some tests can fail due to a different order:

- BusinessIdentityTest.testToString

- BusinessIdentityTest.testGetHashCode

This PR proposes to sort the returned fields and make it deterministic.